### PR TITLE
feat: Add support for --session-id CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-07-16
+
+### Added
+- Support for `--session-id` argument to specify a session ID (UUID) for conversations
+  - Added `session_id` parameter to `ClaudeCodeOptions`
+  - CLI command now includes `--session-id` when session ID is provided
+
 ## [0.1.1] - 2025-07-15
 
 ### Fixed

--- a/lib/claude_sdk/internal/transport/subprocess_cli.rb
+++ b/lib/claude_sdk/internal/transport/subprocess_cli.rb
@@ -340,6 +340,8 @@ module ClaudeSDK
 
         cmd.push("--resume", @options.resume) if @options.resume
 
+        cmd.push("--session-id", @options.session_id) if @options.session_id
+
         if @options.mcp_servers && !@options.mcp_servers.empty?
           mcp_config = { "mcpServers" => serialize_mcp_servers }
           cmd.push("--mcp-config", JSON.generate(mcp_config))

--- a/lib/claude_sdk/types.rb
+++ b/lib/claude_sdk/types.rb
@@ -336,7 +336,8 @@ module ClaudeSDK
       :disallowed_tools,
       :model,
       :permission_prompt_tool_name,
-      :cwd
+      :cwd,
+      :session_id
 
     # Initialize with default values
     #
@@ -354,6 +355,7 @@ module ClaudeSDK
     # @param model [String, nil] model name
     # @param permission_prompt_tool_name [String, nil] permission tool
     # @param cwd [String, Pathname, nil] working directory
+    # @param session_id [String, nil] session ID (must be a valid UUID)
     def initialize(allowed_tools: [],
       max_thinking_tokens: 8000,
       system_prompt: nil,
@@ -367,7 +369,8 @@ module ClaudeSDK
       disallowed_tools: [],
       model: nil,
       permission_prompt_tool_name: nil,
-      cwd: nil)
+      cwd: nil,
+      session_id: nil)
       @allowed_tools = allowed_tools
       @max_thinking_tokens = max_thinking_tokens
       @system_prompt = system_prompt
@@ -382,6 +385,7 @@ module ClaudeSDK
       @model = model
       @permission_prompt_tool_name = permission_prompt_tool_name
       @cwd = cwd
+      @session_id = session_id
 
       validate_permission_mode! if permission_mode
     end
@@ -405,6 +409,7 @@ module ClaudeSDK
       hash[:model] = model if model
       hash[:permission_prompt_tool_name] = permission_prompt_tool_name if permission_prompt_tool_name
       hash[:cwd] = cwd.to_s if cwd
+      hash[:session_id] = session_id if session_id
       hash
     end
 

--- a/lib/claude_sdk/version.rb
+++ b/lib/claude_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSDK
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/claude_sdk/internal/subprocess_cli_spec.rb
+++ b/spec/claude_sdk/internal/subprocess_cli_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe(ClaudeSDK::Internal::SubprocessCLI) do
       expect(cmd).to(include("--resume", "session-123"))
     end
 
+    it "includes session ID when provided" do
+      options = ClaudeSDK::ClaudeCodeOptions.new(
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+      )
+
+      transport = described_class.new(
+        prompt: "Test with session ID",
+        options: options,
+        cli_path: cli_path,
+      )
+
+      cmd = transport.send(:build_command)
+
+      expect(cmd).to(include("--session-id", "550e8400-e29b-41d4-a716-446655440000"))
+    end
+
     it "converts permission modes to camelCase" do
       # Test bypass_permissions
       options = ClaudeSDK::ClaudeCodeOptions.new(


### PR DESCRIPTION
## Summary
- Added support for the new `--session-id` CLI argument introduced in Claude Code
- Users can now specify a session ID (UUID) when creating queries through the SDK
- Version bumped to 0.1.2

## Implementation Details
- Added `session_id` field to `ClaudeCodeOptions` class
- Updated subprocess CLI to include `--session-id` in command when session ID is provided
- Added test coverage for the new functionality

## Test plan
- [x] All existing tests pass
- [x] Added new test case for session ID functionality
- [x] Verified command building includes `--session-id` argument when provided

🤖 Generated with [Claude Code](https://claude.ai/code)